### PR TITLE
Update mail_to helper in ActionView

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -453,7 +453,7 @@ module ActionView
       #   # => <a href="mailto:me@domain.com">
       #          <strong>Email me:</strong> <span>me@domain.com</span>
       #        </a>
-      def mail_to(email_address, name = nil, html_options = {}, &block)
+      def mail_to(name = nil, email_address, html_options = {}, &block)
         html_options, name = name, nil if block_given?
         html_options = (html_options || {}).stringify_keys
 


### PR DESCRIPTION
I think that the mail_to helper should have a structure that is consistent with link_to helper. 

Before my modification:
<%= mail_to email@gmail.com, "Send Email" %>
<% = link_to "Home Page", root_path %>

After my modification:
<%= mail_to "Send Email",  email@gmail.com %>
<% = link_to "Home Page", root_path %>

I think this consistency is important; however, this was a quick commit. I really think that the reverse should be true (link_to should be changed to the structure of mail_to). I'll create another pull request for that later.